### PR TITLE
Remove unused styles

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,21 +8,6 @@
         <item name="colorAccent">@color/colorAccent</item>
     </style>
 
-    <style name="whiteNoise" parent="AppTheme" >
-        <item name="colorPrimary">@color/common_action_bar_splitter</item>
-        <item name="colorPrimaryDark">@color/common_signin_btn_dark_text_pressed</item>
-        <item name="colorAccent">@color/button_material_dark</item>
-    </style>
-
-    <style name="NotificationText">
-        <item name="android:textColor">?android:attr/textColorPrimaryInverse</item>
-        <item name="android:textSize">20dp </item>
-    </style>
-
-    <style name="NotificationButton">
-        <item name="android:colorBackground">@color/button_material_light</item>
-    </style>
-
     <style name="Dark" parent="Theme.AppCompat" />
 
 </resources>


### PR DESCRIPTION
None of these styles are actually used anywhere and keeping them causes confusion as I thought that the notification text and button styles were defined here, but they weren't.
