### PR TITLE
Fixed null pointer exception when service was destroyed

### DIFF
--- a/app/src/main/java/dalbers/com/noise/AudioPlayerService.java
+++ b/app/src/main/java/dalbers/com/noise/AudioPlayerService.java
@@ -160,7 +160,9 @@ public class AudioPlayerService extends Service {
 
     @Override
     public void onDestroy() {
-        player.pause();
+        if (player != null) {
+            player.pause();
+        }
     }
 
     @Override


### PR DESCRIPTION
If you force closed the app while audio was _not_ playing, the app would crash.